### PR TITLE
either one of facility or metro must be given in packetcluster

### DIFF
--- a/api/v1alpha3/packetcluster_types.go
+++ b/api/v1alpha3/packetcluster_types.go
@@ -30,6 +30,7 @@ type PacketClusterSpec struct {
 	ProjectID string `json:"projectID"`
 
 	// Facility represents the Packet facility for this cluster
+	// +optional
 	Facility string `json:"facility,omitempty"`
 
 	// Metro represents the Packet metro for this cluster

--- a/api/v1beta1/packetcluster_types.go
+++ b/api/v1beta1/packetcluster_types.go
@@ -35,6 +35,7 @@ type PacketClusterSpec struct {
 	ProjectID string `json:"projectID"`
 
 	// Facility represents the Packet facility for this cluster
+	// +optional
 	Facility string `json:"facility,omitempty"`
 
 	// Metro represents the Packet metro for this cluster

--- a/api/v1beta1/packetcluster_webhook.go
+++ b/api/v1beta1/packetcluster_webhook.go
@@ -85,6 +85,22 @@ func (c *PacketCluster) ValidateUpdate(oldRaw runtime.Object) error {
 		)
 	}
 
+	// Must have either one of Metro or Facility
+	if len(c.Spec.Facility) == 0 && len(c.Spec.Metro) == 0 {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Metro"),
+				c.Spec.Metro, "field is required when Facility is not set"),
+		)
+	}
+
+	// Must not have both Metro and Facility
+	if len(c.Spec.Facility) > 0 && len(c.Spec.Metro) > 0 {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Facility"),
+				c.Spec.Facility, "field is mutually exclusive with Metro"),
+		)
+	}
+
 	if len(allErrs) == 0 {
 		return nil
 	}

--- a/api/v1beta1/packetmachine_webhook.go
+++ b/api/v1beta1/packetmachine_webhook.go
@@ -61,6 +61,17 @@ func (m *PacketMachine) ValidateUpdate(old runtime.Object) error {
 		})
 	}
 
+	// Either Metro or Facility must be set, but not both
+	if m.Spec.Metro != "" && m.Spec.Facility != "" {
+		return apierrors.NewInvalid(GroupVersion.WithKind("PacketMachine").GroupKind(), m.Name, field.ErrorList{
+			field.Forbidden(field.NewPath("spec", "metro"), "cannot be set when spec.facility is set"),
+		})
+	} else if m.Spec.Metro == "" && m.Spec.Facility == "" {
+		return apierrors.NewInvalid(GroupVersion.WithKind("PacketMachine").GroupKind(), m.Name, field.ErrorList{
+			field.Required(field.NewPath("spec", "metro"), "must be set when spec.facility is not set"),
+		})
+	}
+
 	newPacketMachineSpec, _ := newPacketMachine["spec"].(map[string]interface{})
 	oldPacketMachineSpec, _ := oldPacketMachine["spec"].(map[string]interface{})
 


### PR DESCRIPTION
Make packetcluster facilitates optional
todo: this should be applied to packetmachine too

Supports https://github.com/kubernetes-sigs/cluster-api-provider-packet/pull/448